### PR TITLE
Implement syntax diagram

### DIFF
--- a/public/syntax_diagram.html
+++ b/public/syntax_diagram.html
@@ -1,0 +1,340 @@
+
+<!-- This is a generated file -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+  body {
+    background-color: hsl(30, 20%, 95%)
+  }
+</style>
+
+
+<link rel='stylesheet' href='https://unpkg.com/chevrotain@10.5.0/diagrams/diagrams.css'>
+
+<script src='https://unpkg.com/chevrotain@10.5.0/diagrams/vendor/railroad-diagrams.js'></script>
+<script src='https://unpkg.com/chevrotain@10.5.0/diagrams/src/diagrams_builder.js'></script>
+<script src='https://unpkg.com/chevrotain@10.5.0/diagrams/src/diagrams_behavior.js'></script>
+<script src='https://unpkg.com/chevrotain@10.5.0/diagrams/src/main.js'></script>
+
+<div id="diagrams" align="center"></div>    
+
+<script>
+    window.serializedGrammar = [
+  {
+    "type": "Rule",
+    "name": "query",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "NonTerminal",
+                "name": "booleanClause",
+                "idx": 0
+              },
+              {
+                "type": "NonTerminal",
+                "name": "booleanSuffixClause",
+                "idx": 0
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "NOT",
+                "label": "not",
+                "idx": 0,
+                "pattern": "not"
+              },
+              {
+                "type": "NonTerminal",
+                "name": "query",
+                "idx": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "booleanSuffixClause",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "OR",
+                "label": "or",
+                "idx": 0,
+                "pattern": "or"
+              },
+              {
+                "type": "NonTerminal",
+                "name": "query",
+                "idx": 0
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "AND",
+                "label": "and",
+                "idx": 0,
+                "pattern": "and"
+              },
+              {
+                "type": "NonTerminal",
+                "name": "query",
+                "idx": 1
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "booleanClause",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "NonTerminal",
+                "name": "binaryClause",
+                "idx": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "portItemClause",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "TCP_PORT",
+                "label": "TCP_PORT",
+                "idx": 0,
+                "pattern": "tcp\\.port"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "UDP_PORT",
+                "label": "UDP_PORT",
+                "idx": 0,
+                "pattern": "udp\\.port"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "ipItemClause",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "IP_SRC",
+                "label": "IP_SRC",
+                "idx": 0,
+                "pattern": "ip\\.src"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "IP_DST",
+                "label": "IP_DST",
+                "idx": 0,
+                "pattern": "ip\\.dst"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "binaryClause",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "NonTerminal",
+                "name": "portItemClause",
+                "idx": 0
+              },
+              {
+                "type": "NonTerminal",
+                "name": "binaryOperator",
+                "idx": 0
+              },
+              {
+                "type": "Terminal",
+                "name": "PORT",
+                "label": "PORT",
+                "idx": 0,
+                "pattern": "(?:0|[1-9]\\d*)"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "NonTerminal",
+                "name": "ipItemClause",
+                "idx": 0
+              },
+              {
+                "type": "NonTerminal",
+                "name": "binaryOperator",
+                "idx": 1
+              },
+              {
+                "type": "Terminal",
+                "name": "IPV4",
+                "label": "IPV4",
+                "idx": 0,
+                "pattern": "([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "Rule",
+    "name": "binaryOperator",
+    "orgText": "",
+    "definition": [
+      {
+        "type": "Alternation",
+        "idx": 0,
+        "definition": [
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "EQUAL",
+                "label": "eq",
+                "idx": 0,
+                "pattern": "eq"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "NOT_EQUAL",
+                "label": "ne",
+                "idx": 0,
+                "pattern": "ne"
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "EQUAL_SMB",
+                "label": "eq_smb",
+                "idx": 0,
+                "pattern": "=="
+              }
+            ]
+          },
+          {
+            "type": "Alternative",
+            "definition": [
+              {
+                "type": "Terminal",
+                "name": "NOT_EQUAL_SMB",
+                "label": "ne_smb",
+                "idx": 0,
+                "pattern": "!="
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+];
+</script>
+
+<script>
+    var diagramsDiv = document.getElementById("diagrams");
+    main.drawDiagramsFromSerializedGrammar(serializedGrammar, diagramsDiv);
+</script>

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,5 +1,5 @@
-import { productions } from '../src/dsl';
-import { generateCstDts } from 'chevrotain';
+import { productions, serializedGrammar } from '../src/dsl';
+import { generateCstDts, createSyntaxDiagramsCode } from 'chevrotain';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import process from 'node:process';
@@ -21,7 +21,20 @@ function generateChevrotainDts(): void {
     }
 }
 
+function generateSyntaxDiagram(): void {
+    const htmlText = createSyntaxDiagramsCode(serializedGrammar);
+    const diagramFile = path.resolve(__dirname, '../public/syntax_diagram.html');
+    try {
+        fs.writeFileSync(diagramFile, htmlText);
+        console.log(`Wrote to ${diagramFile}`);
+    } catch (err) {
+        console.error(err);
+        process.exit(1);
+    }
+}
+
 generateChevrotainDts();
+generateSyntaxDiagram();
 
 // 'export {}' statement to make it a module to be able to run using `npm run generate`
 export {};

--- a/src/dsl.ts
+++ b/src/dsl.ts
@@ -6,6 +6,7 @@ import {
     EMPTY_ALT,
     ILexingError,
     IRecognitionException,
+    createSyntaxDiagramsCode,
 } from 'chevrotain';
 import type { QueryCstNode } from './generated/chevrotain_dts';
 
@@ -189,6 +190,9 @@ export interface ParseResult {
 
 export const productions: Record<string, Rule> = parser.getGAstProductions();
 
+// create the HTML Text
+export const serializedGrammar = parser.getSerializedGastProductions();
+
 export function parseDSL(text: string): ParseResult {
     const lexResult = queryLexer.tokenize(text);
 
@@ -202,6 +206,7 @@ export function parseDSL(text: string): ParseResult {
     parser.input = lexResult.tokens;
     // any top level rule may be used as an entry point
     const cst = parser.query();
+    console.log(`the cst is ${JSON.stringify(cst)}`);
 
     return {
         // This is a pure grammar, the value will be undefined until we add embedded actions


### PR DESCRIPTION
This implements syntax diagram view as described at https://chevrotain.io/docs/guide/generating_syntax_diagrams.html. 

I haven't added a button to view the syntax diagram. You can access it by visiting `/syntax_diagram`.
