### PR TITLE
Fix NOT handling in event filter

### DIFF
--- a/public/syntax_diagram.html
+++ b/public/syntax_diagram.html
@@ -56,8 +56,13 @@
               },
               {
                 "type": "NonTerminal",
-                "name": "query",
-                "idx": 0
+                "name": "booleanClause",
+                "idx": 1
+              },
+              {
+                "type": "NonTerminal",
+                "name": "booleanSuffixClause",
+                "idx": 1
               }
             ]
           }

--- a/src/__tests__/dsl.test.ts
+++ b/src/__tests__/dsl.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, test } from '@jest/globals';
 import { parseDSL, productions } from '../dsl';
+import { filterEvent } from '../eventFilter';
+import { generateTestEvent } from '../util';
 
 describe('parseDSL', () => {
     test('parses AND query', () => {
-        let sx = parseDSL('tcp.port eq 23 and tcp.port eq 445');
+        let sx = parseDSL('tcp.port eq 23 and ip.src eq 1.1.1.1');
         expect(sx.lexErrors).toHaveLength(0);
         expect(sx.parseErrors).toHaveLength(0);
 
         // console.log(JSON.stringify(sx, null, 2));
         expect(sx.toString()).toBeTruthy();
+        expect(filterEvent(generateTestEvent(23, '123', '1.1.1.1'), sx.cst)).toBeTruthy();
     });
 
     test('parses ip.src ==', () => {
@@ -18,6 +21,7 @@ describe('parseDSL', () => {
         expect(sx.parseErrors).toHaveLength(0);
         // console.log(JSON.stringify(sx, null, 2));
         expect(sx.toString()).toBeTruthy();
+        expect(filterEvent(generateTestEvent(445, '123', '192.168.1.1'), sx.cst)).toBeTruthy();
     });
 
     test('parses single query with "ne port"', () => {
@@ -26,13 +30,17 @@ describe('parseDSL', () => {
         expect(sx.parseErrors).toHaveLength(0);
         // console.log(JSON.stringify(sx, null, 2));
         expect(sx.toString()).toBeTruthy();
+        expect(filterEvent(generateTestEvent(445, '', '192.168.1.1'), sx.cst)).toBeTruthy();
     });
 
-    test('parses single query with "== port"', () => {
+    test('parses single query with "ne port"', () => {
         let sx = parseDSL('udp.port ne 8080');
         expect(sx.lexErrors).toHaveLength(0);
         expect(sx.parseErrors).toHaveLength(0);
         expect(sx.toString()).toBeTruthy();
+        expect(
+            filterEvent(generateTestEvent(445, '', '192.168.1.1', '', 'Rule: UDP'), sx.cst),
+        ).toBeTruthy();
     });
 
     test('returns lexer error', () => {
@@ -57,5 +65,39 @@ describe('parseDSL', () => {
         let sx = parseDSL('payload contains "something"');
         expect(sx.lexErrors).toHaveLength(0);
         expect(sx.parseErrors).toHaveLength(0);
+        let payload = Buffer.from('something').toString('base64');
+        expect(
+            filterEvent(generateTestEvent(445, '123', '192.168.1.1', payload), sx.cst),
+        ).toBeTruthy();
+    });
+
+    test('parsing payload ne', () => {
+        let sx = parseDSL('not payload contains "banana"');
+        expect(sx.lexErrors).toHaveLength(0);
+        expect(sx.parseErrors).toHaveLength(0);
+        let payload = Buffer.from('something').toString('base64');
+        expect(
+            filterEvent(generateTestEvent(445, '123', '192.168.1.1', payload), sx.cst),
+        ).toBeTruthy();
+    });
+
+    test('payload contains and tcp.port', () => {
+        let sx = parseDSL('payload contains "something" and tcp.port == 445');
+        expect(sx.lexErrors).toHaveLength(0);
+        expect(sx.parseErrors).toHaveLength(0);
+        let payload = Buffer.from('something').toString('base64');
+        expect(
+            filterEvent(generateTestEvent(445, '123', '192.168.1.1', payload), sx.cst),
+        ).toBeTruthy();
+    });
+
+    test('parsing payload ne and tcp.port eq', () => {
+        let sx = parseDSL('not payload contains "banana" and tcp.port != 445');
+        expect(sx.lexErrors).toHaveLength(0);
+        expect(sx.parseErrors).toHaveLength(0);
+        let payload = Buffer.from('something').toString('base64');
+        expect(
+            filterEvent(generateTestEvent(445, '123', '192.168.1.1', payload), sx.cst),
+        ).toBeTruthy();
     });
 });

--- a/src/__tests__/dsl.test.ts
+++ b/src/__tests__/dsl.test.ts
@@ -98,6 +98,6 @@ describe('parseDSL', () => {
         let payload = Buffer.from('something').toString('base64');
         expect(
             filterEvent(generateTestEvent(445, '123', '192.168.1.1', payload), sx.cst),
-        ).toBeTruthy();
+        ).toBeFalsy();
     });
 });

--- a/src/dsl.ts
+++ b/src/dsl.ts
@@ -95,7 +95,8 @@ class QueryParser extends CstParser {
             {
                 ALT: () => {
                     this.CONSUME(not);
-                    this.SUBRULE(this.query);
+                    this.SUBRULE1(this.booleanClause);
+                    this.SUBRULE1(this.booleanSuffixClause);
                 },
             },
         ]);

--- a/src/generated/chevrotain_dts.ts
+++ b/src/generated/chevrotain_dts.ts
@@ -12,7 +12,6 @@ export type QueryCstChildren = {
     booleanClause?: BooleanClauseCstNode[];
     booleanSuffixClause?: BooleanSuffixClauseCstNode[];
     NOT?: IToken[];
-    query?: QueryCstNode[];
 };
 
 export interface BooleanSuffixClauseCstNode extends CstNode {

--- a/src/syntax.md
+++ b/src/syntax.md
@@ -5,7 +5,7 @@ initial query
 
 ```
 query
-   : booleanClause booleanSuffixClause || "NOT" query
+   : booleanClause booleanSuffixClause || "NOT" booleanClause booleanSuffixClause
 
 searchclause
    : payload searchOperator string

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,7 +36,7 @@ function generateRandomString(length: number): string {
     return result;
 }
 /**
- * Generates a random event used for UI testing.
+ * Generates a random event used for UI testing
  * @returns test event
  */
 export function generateRandomTestEvent(): Event {
@@ -52,5 +52,31 @@ export function generateRandomTestEvent(): Event {
         timestamp: now().toString(),
         payload: btoa(`test ${generateRandomString(10 + Math.floor(Math.random() * 100))}`),
         decoded: { test: 123 },
+    };
+}
+
+/**
+ * Generates an event used for testing
+ * @returns test event
+ */
+export function generateTestEvent(
+    dport: number,
+    sport?: string,
+    sip?: string,
+    payload?: string,
+    rule: string = 'Rule: TCP',
+): Event {
+    return {
+        handler: handlers[Math.floor(Math.random() * handlers.length)],
+        connKey: [2, 2],
+        dstPort: dport,
+        rule: rule,
+        scanner: 'censys',
+        sensorID: 'sensorID',
+        srcHost: sip,
+        srcPort: sport,
+        timestamp: now().toString(),
+        payload: payload,
+        decoded: { paload: 'test' },
     };
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,6 +40,7 @@ function generateRandomString(length: number): string {
  * @returns test event
  */
 export function generateRandomTestEvent(): Event {
+    let payload = `test ${generateRandomString(10 + Math.floor(Math.random() * 100))}`;
     return {
         handler: handlers[Math.floor(Math.random() * handlers.length)],
         connKey: [2, 2],
@@ -50,8 +51,8 @@ export function generateRandomTestEvent(): Event {
         srcHost: '1.1.1.1',
         srcPort: '4321',
         timestamp: now().toString(),
-        payload: btoa(`test ${generateRandomString(10 + Math.floor(Math.random() * 100))}`),
-        decoded: { test: 123 },
+        payload: Buffer.from(payload).toString('base64'),
+        decoded: { payload: payload },
     };
 }
 
@@ -77,6 +78,6 @@ export function generateTestEvent(
         srcPort: sport,
         timestamp: now().toString(),
         payload: payload,
-        decoded: { paload: 'test' },
+        decoded: { payload: 'test' },
     };
 }


### PR DESCRIPTION
The existing implementation does not handle `NOT` query properly. It negates the whole query while we want to negate only the closest clause. This PR adjusts the logic to filter the closest clause. The first commit in this PR is copied from https://github.com/honeynet/ochi/pull/64